### PR TITLE
fix: Resolve Critical Router Context Error - useLocation() Issue

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { initializeRouting } from '@/utils/routing'
@@ -15,6 +16,8 @@ if (typeof window !== 'undefined') {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Fixes critical runtime error: `useLocation() may be used only in the context of a <Router> component`
- Wraps App component with BrowserRouter in main.tsx to provide proper Router context
- Enables all React Router hooks to function correctly throughout the application

## Problem Fixed
Multiple components throughout the app use React Router hooks (`useLocation`, `useNavigate`, etc.) but the App component was not wrapped with BrowserRouter, causing a complete application failure.

## Technical Changes
- Added BrowserRouter import to main.tsx
- Wrapped `<App />` with `<BrowserRouter>` in main.tsx
- No other changes needed - all existing routing logic remains intact

## Testing
- [x] Build passes successfully
- [x] TypeScript compilation passes
- [x] Development server starts without errors
- [x] All Router hooks now have proper context

## Impact
- **Critical Fix**: Resolves app-breaking error
- **Zero Breaking Changes**: All existing functionality preserved
- **Improved Stability**: Proper Router context for all components

🤖 Generated with [Claude Code](https://claude.ai/code)