### PR TITLE
feat: reorder home page layout - service boxes first

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -56,34 +56,8 @@ export function Home() {
             </h1>
           </motion.div>
 
-          {/* Instagram Feed Preview */}
-          <motion.div 
-            className="mb-12"
-            variants={boxAnimation}
-          >
-            <InstagramFeed 
-              limit={6}
-              showHeader={false}
-              className="mb-8"
-              useEnhancedHook={true}
-            />
-            <div className="text-center">
-              <a 
-                href="https://instagram.com/rrishmusic" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="inline-flex items-center text-theme-text-secondary hover:text-theme-primary transition-colors"
-              >
-                <span className="mr-2">Follow for more</span>
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
-                </svg>
-              </a>
-            </div>
-          </motion.div>
-
           {/* Two Visual Service Boxes */}
-          <div className="grid md:grid-cols-2 gap-8 h-auto md:h-[400px]">
+          <div className="grid md:grid-cols-2 gap-8 h-auto md:h-[400px] mb-16">
             
             {/* Performances Box - Visual Focus */}
             <motion.div variants={boxAnimation}>
@@ -186,6 +160,33 @@ export function Home() {
             </motion.div>
 
           </div>
+
+          {/* Instagram Feed Preview */}
+          <motion.div 
+            className="mb-12"
+            variants={boxAnimation}
+          >
+            <InstagramFeed 
+              limit={6}
+              showHeader={false}
+              className="mb-8"
+              useEnhancedHook={true}
+            />
+            <div className="text-center">
+              <a 
+                href="https://instagram.com/rrishmusic" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-theme-text-secondary hover:text-theme-primary transition-colors"
+              >
+                <span className="mr-2">Follow for more</span>
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                </svg>
+              </a>
+            </div>
+          </motion.div>
+
         </motion.div>
       </main>
     </>


### PR DESCRIPTION
## Summary
Simple layout improvement based on user feedback to prioritize service navigation on homepage.

## Changes Made
- [x] Moved service boxes (Performances & Lessons) above Instagram feed
- [x] Users now see main navigation options immediately on landing
- [x] Instagram feed positioned below for engagement after main choices
- [x] Added proper spacing between sections
- [x] Maintained all responsive design and animations

## User Experience Improvement
**Before**: Title → Instagram Feed → Service Boxes  
**After**: Title → Service Boxes → Instagram Feed

**Result**: Users immediately see their main options (Performances/Lessons) when landing on the page, with Instagram content as secondary engagement.

## Testing
- [x] TypeScript compilation passes
- [x] Production build successful  
- [x] Responsive layout maintained
- [x] Animations working correctly

🤖 Generated with [Claude Code](https://claude.ai/code)