### PR TITLE
feat: remove navigation spacer for tighter page layouts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,7 +25,6 @@
 
 /* Main Content Area */
 .main-content {
-  padding-top: 4rem; /* Space for fixed navigation */
   position: relative;
   z-index: 1;
 }

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -483,8 +483,6 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({
         )}
       </AnimatePresence>
 
-      {/* Navigation spacer to prevent content overlap */}
-      <div className="h-16" aria-hidden="true" />
     </div>
   )
 }

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -586,8 +586,6 @@ export const Navigation: React.FC<NavigationProps> = ({
         )}
       </nav>
 
-      {/* Navigation spacer to prevent content overlap */}
-      <div className="h-16" aria-hidden="true" />
     </>
   )
 }


### PR DESCRIPTION
Remove navigation spacer divs and main-content padding for more efficient vertical space usage. Content now starts immediately below navigation across all pages, creating tighter, more impactful layouts.