### PR TITLE
feat: remove theme toggle button and set dark mode as default

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -4,7 +4,6 @@ import { Link, useLocation, useNavigate, Location } from 'react-router-dom'
 import { NAVIGATION_ITEMS } from '@/utils/constants'
 import { useSmoothScroll, useScrollSpy } from '@/hooks/useScrollSpy'
 import { useDeviceDetection } from '@/hooks/useDeviceDetection'
-import ThemeToggle from '@/components/ui/ThemeToggle'
 
 interface NavigationProps {
   // Optional activeSection override - mainly for testing
@@ -507,14 +506,12 @@ export const Navigation: React.FC<NavigationProps> = ({
             {device.isDesktop && (
               <div className="desktop-only flex items-center space-x-2">
                 {desktopNavItems}
-                <ThemeToggle size="md" variant="ghost" className="ml-4" />
               </div>
             )}
 
             {/* Mobile Navigation Controls */}
             {!device.isDesktop && (
               <div className="flex items-center space-x-2">
-                <ThemeToggle size="sm" variant="ghost" />
                 <motion.button
                   onClick={toggleMenu}
                   className="mobile-only touch-target-comfortable relative z-50 text-theme-text hover:text-theme-primary transition-colors duration-200"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,7 +147,7 @@ export interface ThemeConfig {
 // Theme constants
 export const THEME_STORAGE_KEY = 'theme-mode'
 export const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)'
-export const DEFAULT_THEME_MODE: ThemeMode = 'system'
+export const DEFAULT_THEME_MODE: ThemeMode = 'dark'
 
 // Basic theme colors for light and dark modes
 export const lightThemeColors: ThemeColors = {


### PR DESCRIPTION
## Summary
- Remove theme toggle button from navigation header
- Set dark mode as the default theme instead of system preference
- Simplify theme management by removing toggle functionality

## Changes Made
- [x] Removed ThemeToggle component import from Navigation.tsx
- [x] Removed ThemeToggle usage from desktop navigation
- [x] Removed ThemeToggle usage from mobile navigation
- [x] Updated DEFAULT_THEME_MODE from 'system' to 'dark' in types/index.ts

## Testing
- [x] TypeScript compilation successful
- [x] Build verification successful
- [x] Dark mode applied by default
- [x] No theme toggle button visible in header

🤖 Generated with [Claude Code](https://claude.ai/code)