### PR TITLE
fix: resolve Instagram posts undefined error

### DIFF
--- a/src/components/sections/InstagramFeed.tsx
+++ b/src/components/sections/InstagramFeed.tsx
@@ -60,7 +60,7 @@ export const InstagramFeed: React.FC<InstagramFeedProps> = memo(
     useEnhancedHook: _useEnhancedHook = true,
     autoRefresh = false,
   }) => {
-    const { posts, loading, error, retry } = useInstagramContent({
+    const { posts = [], loading, error, retry } = useInstagramContent({
       limit,
       autoRefresh,
       refreshInterval: 30 * 60 * 1000, // 30 minutes

--- a/src/components/social/SocialProof.tsx
+++ b/src/components/social/SocialProof.tsx
@@ -260,7 +260,7 @@ const SocialStats: React.FC = () => (
  * Instagram Mini Feed Component
  */
 const InstagramMiniSocial: React.FC = () => {
-  const { posts, loading, error } = useInstagramContent({ limit: 3 })
+  const { posts = [], loading, error } = useInstagramContent({ limit: 3 })
 
   if (loading || error || posts.length === 0) {
     return null

--- a/src/hooks/useInstagramContent.ts
+++ b/src/hooks/useInstagramContent.ts
@@ -78,18 +78,23 @@ export const useInstagramContent = (
 
         if (!mountedRef.current) return
 
+        // Handle direct array return from service
+        const posts = Array.isArray(result) ? result : result?.posts || []
+        const fromCache = Array.isArray(result) ? false : result?.fromCache || false
+        const serviceError = Array.isArray(result) ? null : result?.error || null
+
         setState(prev => ({
           ...prev,
-          posts: result.posts,
-          fromCache: result.fromCache,
-          error: result.error || null,
+          posts,
+          fromCache,
+          error: serviceError,
           loading: false,
-          hasMore: result.posts.length >= effectiveLimit,
+          hasMore: posts.length >= effectiveLimit,
         }))
 
         // Log for debugging
-        if (result.error) {
-          console.warn('Instagram content warning:', result.error)
+        if (serviceError) {
+          console.warn('Instagram content warning:', serviceError)
         }
       } catch (error) {
         if (!mountedRef.current) return


### PR DESCRIPTION
## Summary
Fix critical runtime error: `TypeError: undefined is not an object (evaluating 'p.posts.length')`

## Problem
- useInstagramContent hook expected `result.posts` object structure
- Instagram service returns direct array, causing `undefined.posts` error
- Components crashed when trying to access `posts.length` on undefined

## Solution
- [x] **Fixed hook data handling** - Handle both array and object response formats
- [x] **Added defensive coding** - Default `posts = []` in component destructuring
- [x] **Preserved existing API** - No breaking changes to hook interface
- [x] **Runtime error eliminated** - No more TypeError in browser console

## Changes Made
- **useInstagramContent.ts** - Handle direct array vs object response format
- **InstagramFeed.tsx** - Add `posts = []` default in destructuring
- **SocialProof.tsx** - Add `posts = []` default in destructuring

## Testing
- [x] TypeScript compilation successful
- [x] Build verification successful  
- [x] Runtime error eliminated
- [x] Instagram components render without crashing
- [x] Backward compatibility maintained

## Error Stack Trace Fixed
```
TypeError: undefined is not an object (evaluating 'p.posts.length')
    jd (index-DUH9Vubr.js:49:57791)
    qd (index-DUH9Vubr.js:49:57985)
    [React rendering stack...]
```

🤖 Generated with [Claude Code](https://claude.ai/code)