### PR TITLE
feat: reduce Home page section spacing for tighter layout

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -87,7 +87,7 @@ export function Home() {
         </ErrorBoundary>
 
         {/* 1. Behind-the-scenes section (Instagram feed) */}
-        <div className="py-16 md:py-20">
+        <div className="py-12 md:py-16">
           <ErrorBoundary fallback={<div>Error loading behind-the-scenes</div>}>
             <LazySection fallback={<SectionFallback sectionName="Behind the Scenes" />}>
               <InstagramFeed />
@@ -96,7 +96,7 @@ export function Home() {
         </div>
 
         {/* 2. Portfolio highlights section */}
-        <div className="py-16 md:py-20">
+        <div className="py-12 md:py-16">
           <ErrorBoundary fallback={<div>Error loading portfolio highlights</div>}>
             <LazySection fallback={<SectionFallback sectionName="Portfolio Highlights" />}>
               <PortfolioHighlights />
@@ -106,7 +106,7 @@ export function Home() {
 
         {/* 3. What clients say section (testimonials) */}
         {performanceTestimonials && performanceTestimonials.length > 0 && (
-          <div className="py-16 md:py-20">
+          <div className="py-12 md:py-16">
             <ErrorBoundary fallback={<div>Error loading testimonials</div>}>
               <LazySection fallback={<SectionFallback sectionName="Testimonials" />}>
                 <TestimonialsSection />
@@ -116,7 +116,7 @@ export function Home() {
         )}
 
         {/* 4. Collaboration process section */}
-        <div className="py-16 md:py-20">
+        <div className="py-12 md:py-16">
           <ErrorBoundary fallback={<div>Error loading collaboration process</div>}>
             <LazySection fallback={<SectionFallback sectionName="Collaboration Process" />}>
               <CollaborationProcess />
@@ -125,7 +125,7 @@ export function Home() {
         </div>
 
         {/* 5. Ready to work together section (contact CTA) */}
-        <div className="py-16 md:py-20">
+        <div className="py-12 md:py-16">
           <ErrorBoundary fallback={<div>Error loading contact section</div>}>
             <LazySection fallback={<SectionFallback sectionName="Contact" />}>
               <Contact />


### PR DESCRIPTION
## Summary
Reduces vertical spacing between sections on the Home page from `py-16 md:py-20` to `py-12 md:py-16` for a more compact, efficient layout while maintaining proper visual separation.

## Related Issue
Addresses user request: "Right now on home page you are using py20 between each section. I want you to reduce it to py16 or py12."

## Changes Made
### 📏 Spacing Adjustments
- [x] **Behind-the-scenes section**: py-16 md:py-20 → py-12 md:py-16
- [x] **Portfolio highlights section**: py-16 md:py-20 → py-12 md:py-16
- [x] **Testimonials section**: py-16 md:py-20 → py-12 md:py-16 (conditional)
- [x] **Collaboration process section**: py-16 md:py-20 → py-12 md:py-16
- [x] **Contact CTA section**: py-16 md:py-20 → py-12 md:py-16

### 📱 Responsive Impact
**Mobile (base):**
- Before: `py-16` = 64px top/bottom padding
- After: `py-12` = 48px top/bottom padding
- Reduction: 16px per section (80px total saved)

**Desktop (md+ breakpoint):**
- Before: `md:py-20` = 80px top/bottom padding  
- After: `md:py-16` = 64px top/bottom padding
- Reduction: 16px per section (80px total saved)

## Benefits
### ✨ User Experience
- **More compact layout** with better content-to-whitespace ratio
- **Less scrolling required** to view all content sections
- **Improved content density** without sacrificing readability
- **Better mobile experience** with tighter vertical spacing

### 🎨 Visual Design
- Maintains proper visual separation between sections
- Preserves responsive design principles
- Consistent spacing reduction across all sections
- Professional, polished appearance retained

## Testing
- [x] Local dev server running successfully at http://localhost:5173/
- [x] Build compiles without errors (`npm run build` ✓)
- [x] Hot module reloading confirmed changes applied
- [x] All sections maintain proper spacing hierarchy
- [x] Responsive behavior preserved across breakpoints

## Visual Comparison
**Before:** Sections had generous 64px/80px spacing that created more whitespace than needed
**After:** Tighter 48px/64px spacing provides optimal content density while maintaining professional appearance

🤖 Generated with [Claude Code](https://claude.ai/code)