### PR TITLE
chore: adjust gallery image aspect ratios for improved layout

### DIFF
--- a/src/content/gallery.json
+++ b/src/content/gallery.json
@@ -100,7 +100,7 @@
       "filename": "Rrish solo 3.jpg",
       "category": "portrait",
       "path": "/images/instagram/portrait/Rrish solo 3.jpg",
-      "aspectRatio": 0.65,
+      "aspectRatio": 1.2,
       "priority": "medium"
     },
     {
@@ -114,14 +114,14 @@
       "filename": "Rrish solo 1.jpg",
       "category": "portrait",
       "path": "/images/instagram/portrait/Rrish solo 1.jpg",
-      "aspectRatio": 0.8,
+      "aspectRatio": 0.9,
       "priority": "high"
     },
     {
       "filename": "Rrish_Pop up park-Point Cook.jpg",
       "category": "portrait",
       "path": "/images/instagram/portrait/Rrish_Pop up park-Point Cook.jpg",
-      "aspectRatio": 0.9,
+      "aspectRatio": 1,
       "priority": "low"
     }
   ]


### PR DESCRIPTION
## Summary
Updated aspect ratios for three portrait images in the gallery to improve the mosaic layout balance and visual presentation.

## Changes Made
- Updated Rrish solo 3.jpg aspect ratio from 0.65 to 1.2
- Adjusted Rrish solo 1.jpg aspect ratio from 0.8 to 0.9  
- Modified Rrish_Pop up park-Point Cook.jpg aspect ratio from 0.9 to 1.0

## Testing
- [x] Build verification completed successfully
- [x] TypeScript compilation passed
- [x] Changes improve gallery layout balance

These aspect ratio adjustments enhance the visual flow and balance of the gallery mosaic layout.